### PR TITLE
Update chat tab icon, community title, and chat header style

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { Feather } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
 import { Platform } from 'react-native';
 
@@ -76,7 +77,7 @@ export default function TabLayout() {
         name="chats"
         options={{
           title: 'Chats',
-          tabBarIcon: ({ color }) => <IconSymbol size={24} name="message.fill" color={color} />,
+          tabBarIcon: ({ color }) => <Feather name="message-circle" size={24} color={color} />,
         }}
       />
 

--- a/app/community/_layout.tsx
+++ b/app/community/_layout.tsx
@@ -6,7 +6,7 @@ export default function CommunityLayout() {
       <Stack.Screen 
         name="index" 
         options={{ 
-          title: 'Community', 
+          title: 'Comunidad', 
           headerShown: true
         }} 
       />

--- a/styles/chatStyle.ts
+++ b/styles/chatStyle.ts
@@ -14,7 +14,8 @@ export const getChatsListStyles = (theme: 'light' | 'dark') =>
       backgroundColor: theme === 'dark' ? '#121212' : '#FFF5F8',
     },
     header: {
-      padding: 20,
+      paddingTop: 30,
+      paddingHorizontal: 20,
       paddingBottom: 10,
       alignItems: 'center',
     },


### PR DESCRIPTION
Replaced the chat tab icon with Feather's 'message-circle', changed the community screen title to 'Comunidad', and adjusted chat header padding for improved layout.